### PR TITLE
Fix setTraining endpoint

### DIFF
--- a/mocks/auth.js
+++ b/mocks/auth.js
@@ -73,7 +73,8 @@ module.exports = {
                 }
                 return errorResult('Token not found!')
             }
-        }
+        },
+        getUserIDByToken
     }
 }
   
@@ -104,8 +105,9 @@ function validateCredentials(uid, password) {
     return user?.password === password
 }
 
-function getUserIDByToken(token){
-    return  auth.tokens[token]
+function getUserIDByToken(ctx){
+    const token = ctx.params.token;
+    return auth.tokens[token]
 }
 
 function createTokenForUser(uid){

--- a/mocks/user.js
+++ b/mocks/user.js
@@ -40,7 +40,7 @@ module.exports = {
             params:{
                 username: 'string'
             },   
-            async handler(ctx){
+            handler(ctx){
                 console.log(ctx.params);
                 let result = getUserByUsername(ctx.params.username)
                 return result ? {uid: result} : {}
@@ -62,8 +62,8 @@ module.exports = {
                 token: 'string',
                 training: 'string',
             },
-            handler(ctx) {
-                let userID = (await ctx.call('auth.getUserIDByToken', ctx.params.token)).result
+            async handler(ctx) {
+                let userID = (await ctx.call('auth.getUserIDByToken', { token: ctx.params.token }))
                 return setTraining(userID, ctx.params.training)
             }
         },
@@ -99,7 +99,12 @@ function createUser(username, userID, userObject) {
 }
 
 function setTraining(userID, training) {
-    users[userID].training = training
+    if(users[userID]) {
+        users[userID].training = training
+        return validResult('Sikeres szak választás!')
+    } else {
+        return errorResult('Nem sikerült a szak választás!')
+    }
 }
 
 function getUserByUsername(username){


### PR DESCRIPTION
Export the getUserIDByToken method to be accessible in the user.js file
Because the getUserIDByToken method's parameter isn't the token only, but a context, we should access the token by the ctx.params.token accessor
Add a valid/error result return to the endpoint

[Might be worth a look](https://moleculer.services/docs/0.13/actions.html#Usages)

Closes #5 